### PR TITLE
Fix encoding for movie titles with accents

### DIFF
--- a/allocine.js
+++ b/allocine.js
@@ -4,7 +4,7 @@ exports.action = function(data, callback, config, SARAH){
   
   var url = 'http://mobile.allocine.fr/salle/seances_gen_csalle='+place+'.html';
   var request = require('request');
-  request({ 'uri' : url }, function (err, response, body){
+  request({ 'uri' : url, 'encoding': 'binary' }, function (err, response, body){
     
     if (err || response.statusCode != 200) {
       callback({'tts': "L'action a échoué"});


### PR DESCRIPTION
Using the default request encoding (utf8) returned « ? » values for
movies with accents, as the default mobile website seems to use
iso-8859-1. With ‘binary’ encoding everything works as expected.
